### PR TITLE
New Relic deployment notifications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,39 @@
+#
+# For more information see https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+#
+# However, do not include entire blocks here just because you want to change them.
+# Include only the specific lines that you're changing from the defaults.
+#
+AllCops:
+  TargetRubyVersion: 2.1
+
+Style/IfUnlessModifier:
+  MaxLineLength: 100
+Style/WhileUntilModifier:
+  MaxLineLength: 100
+Metrics/LineLength:
+  Max: 100
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/ClassCheck:
+  Enabled: false
+Style/DotPosition:
+  EnforcedStyle: leading
+Style/IndentHash:
+  EnforcedStyle: consistent
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+Style/BlockDelimiters:
+  EnforcedStyle: semantic
+Style/StringLiterals:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: true
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma

--- a/exe/circleci_deployment_notify_new_relic
+++ b/exe/circleci_deployment_notify_new_relic
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+require 'circleci_deployment_notifier'
+require 'slop'
+require 'uri'
+
+puts "CircleCI Deployment Notify New Relic"
+
+opts = Slop.parse do |o|
+  o.string '-a', '--app-name', 'Name of the application that was deployed (e.g. "Asgard Production")'
+  o.string '-u', '--nr-app-id', 'New Relic App ID'
+  o.on '--version', 'print the version' do
+    puts CircleciDeploymentNotifier::VERSION
+    exit
+  end
+end
+
+unless ENV['CIRCLECI']
+  STDERR.puts "ERROR: This is not a CircleCI build (missing environment variables)."
+  exit 1
+end
+
+app_name = opts[:app_name]
+nr_app_id = opts[:nr_app_id]
+
+if app_name.nil?
+  STDERR.puts "ERROR: Missing App Name"
+  puts opts
+  exit 1
+end
+
+if nr_app_id.nil?
+  STDERR.puts "ERROR: Missing New Relic App ID"
+  puts opts
+  exit 1
+end
+
+CircleciDeploymentNotifier::Build.new(app_name: app_name)
+  .send_to_new_relic(new_relic_app_id: nr_app_id)

--- a/exe/circleci_deployment_notify_new_relic
+++ b/exe/circleci_deployment_notify_new_relic
@@ -8,7 +8,8 @@ puts "CircleCI Deployment Notify New Relic"
 
 opts = Slop.parse do |o|
   o.string '-a', '--app-name', 'Name of the application that was deployed (e.g. "Asgard Production")'
-  o.string '-u', '--nr-app-id', 'New Relic App ID'
+  o.string '-k', '--api-key', 'New Relic API Key'
+  o.string '-i', '--app-id', 'New Relic App ID'
   o.on '--version', 'print the version' do
     puts CircleciDeploymentNotifier::VERSION
     exit
@@ -21,7 +22,8 @@ unless ENV['CIRCLECI']
 end
 
 app_name = opts[:app_name]
-nr_app_id = opts[:nr_app_id]
+app_id = opts[:app_id]
+api_key = opts[:api_key]
 
 if app_name.nil?
   STDERR.puts "ERROR: Missing App Name"
@@ -29,11 +31,17 @@ if app_name.nil?
   exit 1
 end
 
-if nr_app_id.nil?
+if api_key.nil?
+  STDERR.puts "ERROR: Missing New Relic API Key"
+  puts opts
+  exit 1
+end
+
+if app_id.nil?
   STDERR.puts "ERROR: Missing New Relic App ID"
   puts opts
   exit 1
 end
 
 CircleciDeploymentNotifier::Build.new(app_name: app_name)
-  .send_to_new_relic(new_relic_app_id: nr_app_id)
+  .send_to_new_relic(new_relic_api_key: api_key, new_relic_app_id: app_id)

--- a/exe/circleci_deployment_notify_slack
+++ b/exe/circleci_deployment_notify_slack
@@ -20,22 +20,17 @@ unless ENV['CIRCLECI']
   exit 1
 end
 
-# unless ARGV.size == 2
-#   STDERR.puts "Not enough arguments."
-#   print_help
-# end
-
 app_name = opts[:app_name]
 webhook_url = opts[:webhook_url]
 
-if webhook_url.nil?
-  STDERR.puts "ERROR: Missing Slack Webhook URL"
+if app_name.nil?
+  STDERR.puts "ERROR: Missing App Name"
   puts opts
   exit 1
 end
 
-if app_name.nil?
-  STDERR.puts "ERROR: Missing App Name"
+if webhook_url.nil?
+  STDERR.puts "ERROR: Missing Slack Webhook URL"
   puts opts
   exit 1
 end

--- a/lib/circleci_deployment_notifier/build.rb
+++ b/lib/circleci_deployment_notifier/build.rb
@@ -1,5 +1,6 @@
 require "circleci_deployment_notifier/build_info"
 require "circleci_deployment_notifier/slack"
+require "circleci_deployment_notifier/new_relic"
 
 module CircleciDeploymentNotifier
   ##
@@ -17,6 +18,18 @@ module CircleciDeploymentNotifier
     # @param webhook_url [String] Slack Webhook URL
     def send_to_slack(webhook_url:)
       Slack.new(webhook_url: webhook_url, app_name: app_name, build_info: build_info).send
+    end
+
+    ##
+    # Sends a deployment notification to New Relic.
+    # @param new_relic_api_key [String] New Relic API Key
+    # @param new_relic_app_id [String] New Relic Application ID
+    def send_to_new_relic(new_relic_api_key:, new_relic_app_id:)
+      NewRelic.new(
+        new_relic_api_key: new_relic_api_key,
+        new_relic_app_id: new_relic_app_id,
+        build_info: build_info,
+      ).send
     end
 
     private

--- a/lib/circleci_deployment_notifier/new_relic.rb
+++ b/lib/circleci_deployment_notifier/new_relic.rb
@@ -1,0 +1,66 @@
+require 'net/http'
+require 'net/https'
+require 'json'
+
+module CircleciDeploymentNotifier
+  ##
+  # Sends deployment notification to New Relic.
+  # Builds the message using a BuildInfo object.
+  class NewRelic
+    ##
+    # @param new_relic_api_key [String] New Relic API Key
+    # @param new_relic_app_id [String] New Relic Application ID
+    # @param build_info [BuildInfo]
+    def initialize(new_relic_api_key:, new_relic_app_id:, build_info:)
+      self.new_relic_api_key = new_relic_api_key
+      self.new_relic_app_id = new_relic_app_id
+      self.build_info = build_info
+    end
+
+    ##
+    # Sends the deployment notification to New Relic.
+    # @return [Boolean] Whether the request was successful.
+    def send
+      http_response.code == 201
+    end
+
+    private
+
+    attr_accessor :new_relic_api_key
+    attr_accessor :new_relic_app_id
+    attr_accessor :build_info
+
+    def uri
+      URI("https://api.newrelic.com/v2/applications/#{new_relic_app_id}/deployments.json")
+    end
+
+    def http_connection
+      Net::HTTP.new(uri.host, uri.port).tap do |http|
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      end
+    end
+
+    def http_request
+      Net::HTTP::Post.new(uri).tap do |req|
+        req.add_field "X-Api-Key", new_relic_api_key
+        req.add_field "Content-Type", "application/json"
+        req.body = JSON.dump body_data
+      end
+    end
+
+    def body_data
+      {
+        deployment: {
+          revision: build_info.tag_name || build_info.branch_name,
+          user: build_info.builder_username,
+          description: build_info.tag_release_notes_url || build_info.commit_browse_url,
+        }
+      }
+    end
+
+    def http_response
+      @http_response ||= http_connection.request http_request
+    end
+  end
+end

--- a/lib/circleci_deployment_notifier/new_relic.rb
+++ b/lib/circleci_deployment_notifier/new_relic.rb
@@ -55,7 +55,7 @@ module CircleciDeploymentNotifier
           revision: build_info.tag_name || build_info.branch_name,
           user: build_info.builder_username,
           description: build_info.tag_release_notes_url || build_info.commit_browse_url,
-        }
+        },
       }
     end
 

--- a/spec/build_spec.rb
+++ b/spec/build_spec.rb
@@ -1,8 +1,36 @@
 require "spec_helper"
 
-describe CircleciDeploymentNotifier::Build do
+RSpec.describe CircleciDeploymentNotifier::Build do
   subject(:described_instance) { described_class.new(app_name: app_name) }
   let(:app_name) { "Application Name" }
+
+  after do
+    ENV.delete 'CIRCLE_SHA1'
+    ENV.delete 'CIRCLE_BRANCH'
+    ENV.delete 'CIRCLE_TAG'
+    ENV.delete 'CIRCLE_USERNAME'
+    ENV.delete 'CIRCLE_REPOSITORY_URL'
+    ENV.delete 'CIRCLE_BUILD_NUM'
+    ENV.delete 'CIRCLE_BUILD_URL'
+  end
+
+  def prepare_for_branch_build
+    ENV['CIRCLE_SHA1'] = "abc123"
+    ENV['CIRCLE_BRANCH'] = "master"
+    ENV['CIRCLE_USERNAME'] = "RobinDaugherty"
+    ENV['CIRCLE_REPOSITORY_URL'] = "https://github.com/RobinDaugherty/circleci_deployment_notifier"
+    ENV['CIRCLE_BUILD_NUM'] = "1100"
+    ENV['CIRCLE_BUILD_URL'] = "https://circleci.com/gh/RobinDaugherty/circleci_deployment_notifier/1100"
+  end
+
+  def prepare_for_tag_build
+    ENV['CIRCLE_SHA1'] = "abc123"
+    ENV['CIRCLE_TAG'] = "v1.0.0"
+    ENV['CIRCLE_USERNAME'] = "RobinDaugherty"
+    ENV['CIRCLE_REPOSITORY_URL'] = "https://github.com/RobinDaugherty/circleci_deployment_notifier"
+    ENV['CIRCLE_BUILD_NUM'] = "1100"
+    ENV['CIRCLE_BUILD_URL'] = "https://circleci.com/gh/RobinDaugherty/circleci_deployment_notifier/1100"
+  end
 
   describe '#send_to_slack' do
     subject(:send_to_slack) { described_instance.send_to_slack(webhook_url: webhook_url) }
@@ -11,20 +39,7 @@ describe CircleciDeploymentNotifier::Build do
 
     context 'for a branch build' do
       before do
-        ENV['CIRCLE_SHA1'] = "abc123"
-        ENV['CIRCLE_BRANCH'] = "master"
-        ENV['CIRCLE_USERNAME'] = "RobinDaugherty"
-        ENV['CIRCLE_REPOSITORY_URL'] = "https://github.com/RobinDaugherty/circleci_deployment_notifier"
-        ENV['CIRCLE_BUILD_NUM'] = "1100"
-        ENV['CIRCLE_BUILD_URL'] = "https://circleci.com/gh/RobinDaugherty/circleci_deployment_notifier/1100"
-      end
-      after do
-        ENV.delete 'CIRCLE_SHA1'
-        ENV.delete 'CIRCLE_BRANCH'
-        ENV.delete 'CIRCLE_USERNAME'
-        ENV.delete 'CIRCLE_REPOSITORY_URL'
-        ENV.delete 'CIRCLE_BUILD_NUM'
-        ENV.delete 'CIRCLE_BUILD_URL'
+        prepare_for_branch_build
       end
 
       it 'sends a Slack webhook request' do
@@ -52,21 +67,7 @@ describe CircleciDeploymentNotifier::Build do
 
     context 'for a tag build' do
       before do
-        ENV['CIRCLE_SHA1'] = "abc123"
-        ENV['CIRCLE_TAG'] = "v1.0.0"
-        ENV['CIRCLE_USERNAME'] = "RobinDaugherty"
-        ENV['CIRCLE_REPOSITORY_URL'] = "https://github.com/RobinDaugherty/circleci_deployment_notifier"
-        ENV['CIRCLE_BUILD_NUM'] = "1100"
-        ENV['CIRCLE_BUILD_URL'] = "https://circleci.com/gh/RobinDaugherty/circleci_deployment_notifier/1100"
-      end
-      after do
-        ENV.delete 'CIRCLECI'
-        ENV.delete 'CIRCLE_SHA1'
-        ENV.delete 'CIRCLE_TAG'
-        ENV.delete 'CIRCLE_USERNAME'
-        ENV.delete 'CIRCLE_REPOSITORY_URL'
-        ENV.delete 'CIRCLE_BUILD_NUM'
-        ENV.delete 'CIRCLE_BUILD_URL'
+        prepare_for_tag_build
       end
 
       it 'sends a Slack webhook request' do

--- a/spec/build_spec.rb
+++ b/spec/build_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe CircleciDeploymentNotifier::Build do
                 "\"text\":\"<https://github.com/RobinDaugherty/circleci_deployment_notifier/tree/abc123|master>\""\
                 ",\"footer\":\"deployed by <https://github.com/RobinDaugherty|RobinDaugherty> "\
                 "in <https://circleci.com/gh/RobinDaugherty/circleci_deployment_notifier/1100|build 1100>\","\
-                "\"footer_icon\":\"https://github.com/RobinDaugherty.png\"}]}"
+                "\"footer_icon\":\"https://github.com/RobinDaugherty.png\"}]}",
             }
           )
           send_to_slack
@@ -85,7 +85,7 @@ RSpec.describe CircleciDeploymentNotifier::Build do
                 "(<https://github.com/RobinDaugherty/circleci_deployment_notifier/releases/tag/v1.0.0|release notes>)\""\
                 ",\"footer\":\"deployed by <https://github.com/RobinDaugherty|RobinDaugherty> in "\
                 "<https://circleci.com/gh/RobinDaugherty/circleci_deployment_notifier/1100|build 1100>\","\
-                "\"footer_icon\":\"https://github.com/RobinDaugherty.png\"}]}"
+                "\"footer_icon\":\"https://github.com/RobinDaugherty.png\"}]}",
             }
           )
           send_to_slack
@@ -123,7 +123,7 @@ RSpec.describe CircleciDeploymentNotifier::Build do
             body: "{\"deployment\":"\
               "{\"revision\":\"master\",\"user\":\"RobinDaugherty\","\
               "\"description\":\"https://github.com/RobinDaugherty/circleci_deployment_notifier/tree/abc123\"}"\
-              "}"
+              "}",
           )
           send_to_new_relic
           expect(request_with_body).to have_been_made
@@ -146,7 +146,7 @@ RSpec.describe CircleciDeploymentNotifier::Build do
             body: "{\"deployment\":"\
               "{\"revision\":\"v1.0.0\",\"user\":\"RobinDaugherty\","\
               "\"description\":\"https://github.com/RobinDaugherty/circleci_deployment_notifier/releases/tag/v1.0.0\"}"\
-              "}"
+              "}",
           )
           send_to_new_relic
           expect(request_with_body).to have_been_made


### PR DESCRIPTION
Add new command to send New Relic deployment notification.

```sh
usage: circleci_deployment_notify_new_relic [options]
    -a, --app-name    Name of the application that was deployed (e.g. "Asgard Production")
    -k, --api-key  New Relic API Key
    -i, --app-id   New Relic App ID
    --version         print the version
```
