### PR TITLE
Support REPOSITORY_URL being an SSH git URL

### DIFF
--- a/lib/circleci_deployment_notifier/build_info.rb
+++ b/lib/circleci_deployment_notifier/build_info.rb
@@ -48,7 +48,9 @@ module CircleciDeploymentNotifier
     end
 
     def repository_url
-      ENV['CIRCLE_REPOSITORY_URL']
+      ENV['CIRCLE_REPOSITORY_URL'].sub(/\Agit@([-\.a-z]+):(.+)\.git\z/) { |m|
+        "https://#{$1}/#{$2}"
+      }
     end
 
     def build_identifier


### PR DESCRIPTION
CircleCI 2.0 uses an SSH git URL, e.g. `git@github.com:org/repo.git` instead of the HTTPS URL that we've relied on. They don't have an HTTPS url anywhere that we can use, so we must rewrite the SSH URL to be usable.